### PR TITLE
Raise interval maximum value

### DIFF
--- a/plasmoid/contents/ui/config/ConfigGeneral.qml
+++ b/plasmoid/contents/ui/config/ConfigGeneral.qml
@@ -27,6 +27,7 @@ ConfigPage {
         SpinBox {
             id: interval
             Layout.fillWidth: true            
+            maximumValue: 99999
         }
     }
     


### PR DESCRIPTION
Allows for intervals as long as 1 day. This was defaulted to 99.