### PR TITLE
Cut right dropdown margin if no hyperlink, image, submenu, and add dropdown arrow visible option.

### DIFF
--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -26,7 +26,7 @@
     <entry name="height" type="int">
       <default>600</default>
     </entry>
-    <entry name="d_arrownevervisible" type="Bool">
+    <entry name="d_ArrowNeverVisible" type="Bool">
         <default>true</default>
     </entry>
   </group>

--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -26,8 +26,8 @@
     <entry name="height" type="int">
       <default>600</default>
     </entry>
-    <entry name="dropdownvisible" type="bool">
-      <default>false</default>
+    <entry name="d_arrownevervisible" type="Bool">
+        <default>true</default>
     </entry>
   </group>
 </kcfg>

--- a/plasmoid/contents/ui/CompactRepresentation.qml
+++ b/plasmoid/contents/ui/CompactRepresentation.qml
@@ -67,7 +67,7 @@ Item {
             implicitWidth: units.iconSizes.smallMedium
             implicitHeight: units.iconSizes.smallMedium
 
-            visible: (root.dropdownItemsCount > 0) && (!plasmoid.configuration.d_arrownevervisible) && (mouseIsInside || plasmoid.expanded || plasmoid.configuration.d_arrowalwaysvisible)
+            visible: (root.dropdownItemsCount > 0) && (!plasmoid.configuration.d_ArrowNeverVisible) && (mouseIsInside || plasmoid.expanded || plasmoid.configuration.d_ArrowAlwaysVisible)
 
             anchors {
                 right: parent.right

--- a/plasmoid/contents/ui/CompactRepresentation.qml
+++ b/plasmoid/contents/ui/CompactRepresentation.qml
@@ -6,13 +6,13 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 
 
 Item {
-    
+
     id: compactRoot
-    
+
     Layout.preferredWidth: rotator.implicitWidth + (dropdownButton.visible?dropdownButton.implicitWidth + 5 : 0)
 
     property var mouseIsInside: false;
-    
+
     MouseArea {
         id: mousearea
         hoverEnabled: true
@@ -26,7 +26,7 @@ Item {
         onExited: {
             mouseExitDelayer.restart();
         }
-        
+
         onClicked: {
             if (!rotator.mousearea.hasClickAction && root.dropdownItemsCount > 0) {
                 doDropdown();
@@ -67,7 +67,7 @@ Item {
             implicitWidth: units.iconSizes.smallMedium
             implicitHeight: units.iconSizes.smallMedium
 
-            visible: root.dropdownItemsCount > 0 && (mouseIsInside || plasmoid.expanded || plasmoid.configuration.dropdownvisible)
+            visible: (root.dropdownItemsCount > 0) && (!plasmoid.configuration.d_arrownevervisible) && (mouseIsInside || plasmoid.expanded || plasmoid.configuration.d_arrowalwaysvisible)
 
             anchors {
                 right: parent.right

--- a/plasmoid/contents/ui/FullRepresentation.qml
+++ b/plasmoid/contents/ui/FullRepresentation.qml
@@ -3,7 +3,6 @@ import org.kde.plasma.components 2.0 as PlasmaComponents
 import QtQuick.Controls 1.4
 import QtQuick.Layouts 1.1
 import org.kde.plasma.core 2.0 as PlasmaCore
-import org.kde.plasma.calendar 2.0 as PlasmaCalendar
 
 Item {
     id: fullRoot
@@ -98,11 +97,15 @@ Item {
                 if (typeof model.imageHeight !== 'undefined') {
                     image.sourceSize.height = model.imageHeight
                 }
+
+                if (typeof model.image !== 'undefined' && typeof model.imageURL !== 'undefined') {
+                    image.width = 0;
+                }
             }
             
             Item {
                 id: labelAndButtons
-                width:  fullRoot.width - icon.width - arrow_icon.width - image.width//some right margin
+                width: fullRoot.width - icon.width - arrow_icon.width - image.width//some right margin
                 height: itemLabel.implicitHeight + 10
                 anchors.verticalCenter: row.verticalCenter
 
@@ -138,7 +141,7 @@ Item {
                 source: (fullRoot.categories[model.title] !== undefined && fullRoot.categories[model.title].visible) ? 'arrow-down': 'arrow-up'
                 visible: (typeof model.category === 'undefined' && fullRoot.categories[model.title] !== undefined && fullRoot.categories[model.title].items.length > 0) ? true:false
 
-                width: units.iconSizes.smallMedium
+                width: (visible) ? units.iconSizes.smallMedium : 0
                 height: units.iconSizes.smallMedium
 
                 MouseArea {

--- a/plasmoid/contents/ui/config/ConfigAppearance.qml
+++ b/plasmoid/contents/ui/config/ConfigAppearance.qml
@@ -11,9 +11,9 @@ ConfigPage {
     property alias cfg_width: width.value
     property alias cfg_compactLabelMaxWidth: compactLabelMaxWidth.value
     property alias cfg_height: height.value
-    property alias cfg_d_arrownevervisible: d_arrownevervisible.checked
-    property alias cfg_d_arrowalwaysvisible: d_arrowalwaysvisible.checked
-    property alias cfg_d_arrowvisibleasneeded: d_arrowvisibleasneeded.checked
+    property alias cfg_d_ArrowNeverVisible: d_ArrowNeverVisible.checked
+    property alias cfg_d_ArrowAlwaysVisible: d_ArrowAlwaysVisible.checked
+    property alias cfg_d_ArrowVisibleAsNeeded: d_ArrowVisibleAsNeeded.checked
 
 
     ConfigSection {
@@ -56,17 +56,17 @@ ConfigPage {
             ColumnLayout {
                 ExclusiveGroup { id: dropdownArrowVisibleGroup }
                 RadioButton {
-                    id: d_arrowalwaysvisible
+                    id: d_ArrowAlwaysVisible
                     text: i18n('Always visible')
                     exclusiveGroup: dropdownArrowVisibleGroup
                 }
                 RadioButton {
-                    id: d_arrowvisibleasneeded
+                    id: d_ArrowVisibleAsNeeded
                     text: i18n('Visible as needed')
                     exclusiveGroup: dropdownArrowVisibleGroup
                 }
                 RadioButton {
-                    id: d_arrownevervisible
+                    id: d_ArrowNeverVisible
                     text: i18n('Never visible')
                     exclusiveGroup: dropdownArrowVisibleGroup
                 }

--- a/plasmoid/contents/ui/config/ConfigAppearance.qml
+++ b/plasmoid/contents/ui/config/ConfigAppearance.qml
@@ -7,49 +7,71 @@ import org.kde.plasma.extras 2.0 as PlasmaExtras
 
 ConfigPage {
     id: page
-    
+
     property alias cfg_width: width.value
     property alias cfg_compactLabelMaxWidth: compactLabelMaxWidth.value
     property alias cfg_height: height.value
-    property alias cfg_dropdownvisible: dropdownvisible.checked
-    
-    
+    property alias cfg_d_arrownevervisible: d_arrownevervisible.checked
+    property alias cfg_d_arrowalwaysvisible: d_arrowalwaysvisible.checked
+    property alias cfg_d_arrowvisibleasneeded: d_arrowvisibleasneeded.checked
+
+
     ConfigSection {
         label: i18n("Preferred width in px")
-        
+
         SpinBox {
             id: width
-            Layout.fillWidth: true        
-            maximumValue: 10000
-        }
-    }
-    
-    ConfigSection {
-        label: i18n("Preferred height in px")
-        
-        SpinBox {
-            id: height
-            Layout.fillWidth: true        
-            maximumValue: 10000
-        }
-    }
-    
-    ConfigSection {
-        label: i18n("Compact (on panel) fixed text width (0: unlimited)")
-        
-        SpinBox {
-            id: compactLabelMaxWidth
-            Layout.fillWidth: true        
+            Layout.fillWidth: true
             maximumValue: 10000
         }
     }
 
     ConfigSection {
-        
-        CheckBox {
-            id: dropdownvisible
+        label: i18n("Preferred height in px")
+
+        SpinBox {
+            id: height
             Layout.fillWidth: true
-            text: 'Dropdown always visible'
+            maximumValue: 10000
         }
+    }
+
+    ConfigSection {
+        label: i18n("Compact (on panel) fixed text width (0: unlimited)")
+
+        SpinBox {
+            id: compactLabelMaxWidth
+            Layout.fillWidth: true
+            maximumValue: 10000
+        }
+    }
+
+    ConfigSection {
+
+        GroupBox {
+            title: i18n('Dropdown arrow visible option: ')
+            anchors.left: parent.left
+            Layout.columnSpan: 2
+
+            ColumnLayout {
+                ExclusiveGroup { id: dropdownArrowVisibleGroup }
+                RadioButton {
+                    id: d_arrowalwaysvisible
+                    text: i18n('Always visible')
+                    exclusiveGroup: dropdownArrowVisibleGroup
+                }
+                RadioButton {
+                    id: d_arrowvisibleasneeded
+                    text: i18n('Visible as needed')
+                    exclusiveGroup: dropdownArrowVisibleGroup
+                }
+                RadioButton {
+                    id: d_arrownevervisible
+                    text: i18n('Never visible')
+                    exclusiveGroup: dropdownArrowVisibleGroup
+                }
+            }
+        }
+
     }
 }

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -10,6 +10,7 @@ import org.kde.kquickcontrolsaddons 2.0
 Item {
     id: root
     
+    // status bar only show icon, no words if constrained
     Plasmoid.preferredRepresentation: isConstrained() ? Plasmoid.compactRepresentation : Plasmoid.fullRepresentation
     //Plasmoid.preferredRepresentation: Plasmoid.compactRepresentation
 
@@ -75,6 +76,7 @@ Item {
             
             var attributesToken = line.split('|')[1].trim();
             
+            // replace \' to string __ESCAPED_QUOTE__
             attributesToken = attributesToken.replace(/\\'/g, '__ESCAPED_QUOTE__');
             var tokens = attributesToken.match(/([^\s']+=[^\s']+|[^\s']+='[^']*')+/g)
             tokens.forEach(function(attribute_value) {
@@ -84,6 +86,7 @@ Item {
             });
         }
 
+        // submenus
         if (parsedObject.title.match(/^--/)) {
             parsedObject.title = parsedObject.title.substring(2).trim();
             if (currentCategory !== undefined) {


### PR DESCRIPTION
1. if no hyperlink, image, submenus, no margin on the right of dropdown.
2. could choose dropdown arrow on status bar always visible, never visible or visible as needed(mouse click).

![image](https://user-images.githubusercontent.com/9500049/53387790-66f13300-39c3-11e9-8262-43a6b4709a49.png)
