### PR TITLE
Allow settings the command from plasmoidviewer

### DIFF
--- a/plasmoid/contents/ui/FirstLinesRotator.qml
+++ b/plasmoid/contents/ui/FirstLinesRotator.qml
@@ -85,7 +85,7 @@ Row {
         rotatingItems = newItems;
         
         
-        if (plasmoid.configuration.command == '') {
+        if (root.command == '') {
             label.text = 'No command configured. Go to settings...';
         } else {
             updateItems();

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -243,9 +243,24 @@ Item {
                 function(item) {
                     return item.dropdown === undefined || item.dropdown !== 'false'
                 }).length;
-                
+
             if (stdout.indexOf('---') === -1) {
                 plasmoid.expanded = false
+            }
+        }
+    }
+
+    Connections {
+        target: plasmoid
+        // `externalData` is emitted when the containment decides to send data to a plasmoid.
+        // More usefully (for us at least), plasmoidviewer also sends its first argument this way.
+        // So, for development we can do:
+        // $ plasmoidviewer -a ./plasmoid "echo hello world"
+        // and this will set the command as "echo hello world".
+        onExternalData: function (mimeType, data) {
+            console.debug(`Got '${data}' as externalData.`);
+            if (!command) {
+                command = data;
             }
         }
     }


### PR DESCRIPTION
It turns out plasmoidviewer sends its first positional argument to its plasmoid as externalData.
This makes kargos listen to it, allowing us to easily set the command during development.