### PR TITLE
Replace fancy ES6 format string with regular string concat

### DIFF
--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -258,7 +258,7 @@ Item {
         // $ plasmoidviewer -a ./plasmoid "echo hello world"
         // and this will set the command as "echo hello world".
         onExternalData: function (mimeType, data) {
-            console.debug(`Got '${data}' as externalData.`);
+            console.debug("Got externalData: " + data);
             if (!command) {
                 command = data;
             }


### PR DESCRIPTION
I'm thinking since Qt 5.9 was only released in 2018, its bundled JS interpreter doesn't support ES2017 format strings.

Hopefully, this fixes #37 