### PR TITLE
trimming only the end of the string, for alignment

### DIFF
--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -92,7 +92,7 @@ Item {
         var parsedObject = {title: line};
         
         if (line.indexOf('|') != -1) {
-            parsedObject.title = line.split('|')[0].trim();
+            parsedObject.title = line.split('|')[0].replace(/\s+$/, '');
             
             var attributesToken = line.split('|')[1].trim();
             


### PR DESCRIPTION
I only needed this change because I have some multi-line entries (upload & download speeds, with \n in the string) that would not line up in kargos the way they did in argos.

I left the other trim() statements alone, as I didn't want to break the submenu functionality.

Let me know if it needs any other cleanup.

Thanks!
